### PR TITLE
Add note for Linux distributions powered by PipeWire

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,45 +6,54 @@ audio files. This virtual soundcard, however, is designed to transmit audio
 PCM data received from various programs directly into a FIFO file.
 
 ## Prerequisites
+
 The following packages must be installed before building `vsnd`.
 
 To compile the kernel driver successfully, package versions of currently used
 kernel, kernel-devel and kernel-headers need to be matched.
+
 ```shell
 $ sudo apt install linux-headers-$(uname -r)
 ```
 
 Additional packages are required for verification purpose.
+
 ```shell
 $ sudo apt install alsa-utils ffmpeg
 ```
 
 ## Build and Run
+
 After running make, you should be able to generate the file `vsnd.ko`.
 
 Before loading this kernel module, you have to satisfy its dependency:
+
 ```shell
 $ sudo modprobe snd_pcm
 ```
 
 A FIFO file is required during kernel module initialization and is used for
 transmitting audio PCM data.
+
 ```shell
 $ mkfifo /tmp/audio.pcm
 ```
 
 The module can be loaded to Linux kernel by runnning the command:
-```
+
+```shell
 $ sudo insmod vsnd.ko out_fifo_name=/tmp/audio.pcm
 ```
 
 Then, use [aplay](https://manpages.org/aplay) to check the soundcard device
 provided by `vsnd`.
+
 ```shell
 $ aplay -l
 ```
 
 Reference output:
+
 ```
 card 0: vsnd [vsnd], device 0: vsnd PCM [vsnd PCM]
   Subdevices: 1/1
@@ -59,7 +68,8 @@ If your system uses PulseAudio to control the sound ouput
 device (i.e., sink), you may undergo
 with the following error when you select the sink
 as `vsnd` from PulseAudio then you try to remove `vsnd`:
-```
+
+```shell
 $ sudo rmmod vsnd
 rmmod: ERROR: Module vsnd is in use
 ```
@@ -68,21 +78,25 @@ The reason is that PulseAudio occupies `vsnd`. Though you can
 tell PulseAudio to disable `vsnd` so that you can remove `vsnd`,
 we suggest you to disable temporarily when using `vsnd` by the following
 command:
-```
+
+```shell
 $ systemctl --user stop pulseaudio.socket
 $ systemctl --user stop pulseaudio.service
 ```
 
 After using `vsnd`, you can execute the following command to bring
 back PulseAudio:
-```
+
+```shell
 $ systemctl --user start pulseaudio.service
 $ systemctl --user start pulseaudio.socket
 ```
 
 ## License
+
 `vsnd`is released under the MIT license. Use of this source code is governed by
 a MIT-style license that can be found in the LICENSE file.
 
 ## Reference
+
 * [The ALSA Driver API](https://www.kernel.org/doc/html/latest/sound/kernel-api/alsa-driver-api.html)

--- a/README.md
+++ b/README.md
@@ -92,6 +92,24 @@ $ systemctl --user start pulseaudio.service
 $ systemctl --user start pulseaudio.socket
 ```
 
+### Run on PipeWire-enabled environment
+
+In systems use the PipeWire (e.g., Ubuntu 24.04 LTS), you might also encounter
+the problem that you are not able to remove the vsnd module.
+
+To solve this problem, you need to stop the PipeWire with:
+
+```shell
+$ systemctl --user stop pipewire.socket
+$ systemctl --user stop pipewire
+```
+
+And after removing the module, restart it with:
+
+```shell
+$ systemctl --user start pipewire
+```
+
 ## License
 
 `vsnd`is released under the MIT license. Use of this source code is governed by


### PR DESCRIPTION
This PR adds a simple guide to solve the `rmmod` problem in PipeWire-enabled system.

Similar to the problem in PulseAudio-enabled system, for systems using pipewire, we might also not able to remove the vsnd module from kernel directly.

```
vm@vm:~/mnt/vsnd$ sudo rmmod vsnd 
rmmod: ERROR: Module vsnd is in use

vm@vm:~/mnt/vsnd$ systemctl --user status pipewire
● pipewire.service - PipeWire Multimedia Service
     Loaded: loaded (/usr/lib/systemd/user/pipewire.service; enabled; preset: enabled)
     Active: active (running) since Sat 2024-05-04 19:05:17 CST; 4h 45min ago
TriggeredBy: ● pipewire.socket
   Main PID: 12797 (pipewire)
      Tasks: 3 (limit: 4615)
     Memory: 4.3M (peak: 4.5M)
        CPU: 38ms
     CGroup: /user.slice/user-1000.slice/user@1000.service/session.slice/pipewire.service
             └─12797 /usr/bin/pipewire

May 04 19:05:17 vm systemd[2077]: Started pipewire.service - PipeWire Multimedia Service.
May 04 19:05:17 vm pipewire[12797]: mod.jackdbus-detect: Failed to receive jackdbus reply: org.freedesktop.DBus.Error.ServiceUnknown:>
vm@vm:~/mnt/vsnd$ systemctl --user status pipewire.socket 
● pipewire.socket - PipeWire Multimedia System Sockets
     Loaded: loaded (/usr/lib/systemd/user/pipewire.socket; enabled; preset: enabled)
     Active: active (running) since Sat 2024-05-04 19:05:17 CST; 4h 45min ago
   Triggers: ● pipewire.service
     Listen: /run/user/1000/pipewire-0 (Stream)
             /run/user/1000/pipewire-0-manager (Stream)
     CGroup: /user.slice/user-1000.slice/user@1000.service/app.slice/pipewire.socket

May 04 19:05:17 vm systemd[2077]: Listening on pipewire.socket - PipeWire Multimedia System Sockets.

```

To address this problem, we can stop the pipewire service before using the `rmmod` command:

```
vm@vm:~/mnt/vsnd$ systemctl --user stop pipewire.socket 
vm@vm:~/mnt/vsnd$ systemctl --user stop pipewire
vm@vm:~/mnt/vsnd$ sudo rmmod vsnd
vm@vm:~/mnt/vsnd$ echo $?
0
```

And we should restart the pipewire service after `rmmod`:

```
vm@vm:~/mnt/vsnd$ systemctl --user start pipewire
vm@vm:~/mnt/vsnd$ systemctl --user status pipewire
● pipewire.service - PipeWire Multimedia Service
     Loaded: loaded (/usr/lib/systemd/user/pipewire.service; enabled; preset: enabled)
     Active: active (running) since Sat 2024-05-04 23:54:18 CST; 6s ago
TriggeredBy: ● pipewire.socket
   Main PID: 13335 (pipewire)
      Tasks: 3 (limit: 4615)
     Memory: 4.2M (peak: 4.4M)
        CPU: 42ms
     CGroup: /user.slice/user-1000.slice/user@1000.service/session.slice/pipewire.service
             └─13335 /usr/bin/pipewire

May 04 23:54:18 vm systemd[2077]: Started pipewire.service - PipeWire Multimedia Service.
May 04 23:54:18 vm pipewire[13335]: mod.jackdbus-detect: Failed to receive jackdbus reply: org.freedesktop.DBus.Error.ServiceUnknown:>
vm@vm:~/mnt/vsnd$ systemctl --user status pipewire.socket
● pipewire.socket - PipeWire Multimedia System Sockets
     Loaded: loaded (/usr/lib/systemd/user/pipewire.socket; enabled; preset: enabled)
     Active: active (running) since Sat 2024-05-04 23:54:18 CST; 10s ago
   Triggers: ● pipewire.service
     Listen: /run/user/1000/pipewire-0 (Stream)
             /run/user/1000/pipewire-0-manager (Stream)
     CGroup: /user.slice/user-1000.slice/user@1000.service/app.slice/pipewire.socket

May 04 23:54:18 vm systemd[2077]: Listening on pipewire.socket - PipeWire Multimedia System Sockets.
```