### PR TITLE
Check fifo file with the S_ISFIFO macro

### DIFF
--- a/vsnd.c
+++ b/vsnd.c
@@ -24,7 +24,6 @@ MODULE_VERSION("0.1");
 static int is_fifo_file(char *filename)
 {
     struct path path;
-    struct inode *inode;
     int err;
 
     if (!filename) {
@@ -36,8 +35,7 @@ static int is_fifo_file(char *filename)
     if (err < 0)
         goto finally;
 
-    inode = path.dentry->d_inode;
-    err = ((inode->i_mode & S_IFMT) == S_IFIFO ? 0 : -EIO);
+    err = (S_ISFIFO(path.dentry->d_inode->i_mode) ? 0 : -EIO);
 
     path_put(&path);
 


### PR DESCRIPTION
There are serveral advantages by using the macro:

1. hide the bitwise operations by using `S_ISFIFO`, which has a more
   informative name, to improve the code readability

2. make the code more compact, so that the whole expression to check the
   file type can fit in one line, and there is no need to use the inode
   pointer, which is not used in other places

3. the implementation of `S_ISFIFO` is maintained by the kernel, so it
   will not affect the module code in case that the kernel changes the
   name of `S_IFIFO` or `S_IFMT`, though it might not be likely to
   happen
